### PR TITLE
fix(config-parser): make output directory if it doesn't exist

### DIFF
--- a/src/circuit.ts
+++ b/src/circuit.ts
@@ -6,6 +6,7 @@ const {wasm: wasmTester} = require("./vendors/circom_tester")
 import {CircuitConfig, Networks, Witness, ZK_PROOF} from "./types";
 import {genGrothZKey, genPlonkZKey, genVerificationKey} from "./utils/zKey";
 import {genGroth16Proof, genPlonkProof, verifyGroth16Proof, verifyPlonkProof} from "./utils/proof";
+import * as fs from "fs";
 
 export class Circuit {
     private _circuitConfig: CircuitConfig;
@@ -21,6 +22,10 @@ export class Circuit {
 
     async compile() {
         log.info('compiling circuit:%s, out1:%s', this._circuitConfig.inputFilePath, this._circuitConfig.outputDir)
+
+        if(!fs.existsSync(this._circuitConfig.outputDir)) {
+             fs.mkdirSync(this._circuitConfig.outputDir, {recursive:true})
+        }
 
         this._wasmTester = await wasmTester(this._circuitConfig.inputFilePath, {
             output: this._circuitConfig.outputDir,

--- a/src/configParser.ts
+++ b/src/configParser.ts
@@ -57,13 +57,19 @@ export class ConfigParser {
 
       // Check if ouput directory path is valid
       const outputDirectory = path.resolve(parsedConfig.outputDir);
-      try {
-        fs.accessSync(outputDirectory, fs.constants.W_OK);
-      } catch (err) {
-        throw new Error(
-          `Output directory is not writable. Please check outputDir in config json, filepath:${this._fp}`
-        );
-      }
+        if(!fs.existsSync(outputDirectory)){
+          fs.mkdirSync(outputDirectory, {recursive:true})
+        }
+        else {
+          try {
+          fs.accessSync(outputDirectory, fs.constants.W_OK);
+          }
+          catch (err) {
+            throw new Error(
+                `Output directory is not writable. Please check outputDir in config json, filepath:${this._fp}`
+            );
+          }
+        }
 
       return Object.assign({}, parsedConfig);
     } catch (err) {


### PR DESCRIPTION
fixes [this](https://github.com/getZeFi/circomjs/issues/19).